### PR TITLE
生成二维码为特定release版本

### DIFF
--- a/lib/fir/util/publish.rb
+++ b/lib/fir/util/publish.rb
@@ -138,8 +138,11 @@ module FIR
       logger.info "Published succeed: #{short}"
 
       if @export_qrcode
+        release_info = get(fir_api[:app_url]+"/#{@app_id}/releases",api_token:@token)
+        release_id = release_info[:datas][0][:id]
+        release_url = "#{short}?release_id=#{release_id}"
         qrcode_path = "#{File.dirname(@file_path)}/fir-#{@app_info[:name]}.png"
-        FIR.generate_rqrcode(short, qrcode_path)
+        FIR.generate_rqrcode(release_url, qrcode_path)
 
         logger.info "Local qrcode file: #{qrcode_path}"
       end


### PR DESCRIPTION
由于相同bundle id在fir上会有一个固定地址，但是同一个bundle id可能有不同版本，为了跟踪记录需要记录不同release的url。
