### PR TITLE
fix: 提示用户新版本可能出现的 bug

### DIFF
--- a/doc/build_ipa.md
+++ b/doc/build_ipa.md
@@ -57,6 +57,8 @@ Options:
   ```sh
   $ fir build_ipa path/to/workspace -w -S <scheme name>
   ```
+  
+**注意:** 这里填写的路径应该是项目的路径, 而不应该是 workspace 文件的路径(例: `fir build_ipa path/to/workspace/example.xcworkspace`), 要不然就会提示 `The xcworkspace file is missing, check the BUILD_DIR` 的 Error.
 
 
 **ChangeLog 1.6.0**


### PR DESCRIPTION
#133 

旧版本里使用下面这条命令是可以正常运行的, 而新版本里则会提示 `The xcodeproj file is missing, check the BUILD_DIR` 的 Error

```shell
fir build_ipa Example/Example.xcworkspace --workspace
```

改成下面这样, 就可以正常运行

```shell
fir build_ipa Example --workspace
```

翻了一下源码我才发现了`@build_dir` 会被赋值为 `Example/Example.xcworkspace`, 然后在 workspace 文件夹里面寻找 `Example.xcodeproj` 文件, 才导致了这个 "bug" 的产生

我猜测之前版本的逻辑会自动忽略掉 workspace 那个路径, 所以不会出这个问题, 我也一直以为这是正确的打开方式, 所以一直沿用着, 可能也有一部分跟我一样, 所以我在文档里加上了相关的提示