### PR TITLE
删除 build_ipa.rb 中 dsym_name 的空格

### DIFF
--- a/lib/fir/util/build_ipa.rb
+++ b/lib/fir/util/build_ipa.rb
@@ -171,7 +171,7 @@ module FIR
       end
 
       @builded_app_path = "#{@output_path}/#{@ipa_name}.ipa"
-      dsym_name = " #{@output_path}/#{ipa_info[:name]}.app.dSYM"
+      dsym_name = "#{@output_path}/#{ipa_info[:name]}.app.dSYM"
 
       FileUtils.mv(@temp_ipa, @builded_app_path, force: true)
       if File.exist?(dsym_name)


### PR DESCRIPTION
该问题导致 fir build_ipa 上传时找不到 dYSM 文件