### PR TITLE
修复 fir.sh 脚本在 ubuntu 上运行提示格式错误

### DIFF
--- a/fir.sh
+++ b/fir.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #  because fir-cli dependent ruby enviroment, this shell is dependent ruby docker
 #  so xcode and gradle not use
 #  this shell only use to publish apk or ipa , build is not run


### PR DESCRIPTION
按照 Readme 运行 fir.sh 脚本上传 apk, 但是在 ubuntu CI 服务器上会提示如下错误：

```
#!/bin/bash -eo pipefail
sudo curl https://raw.githubusercontent.com/FIRHQ/fir-cli/master/fir.sh -o /usr/local/bin/fir
sudo chmod +x /usr/local/bin/fir
fir login xxxxxxxxxxxxxxxxxxxxxxx
fir publish /tmp/workspace/xxxxx.apk
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

100   970  100   970    0     0   7600      0 --:--:-- --:--:-- --:--:--  7637
/usr/local/bin/fir: 14: /usr/local/bin/fir: Syntax error: "(" unexpected
Exited with code 2
```
将文件头声明为 `#/bin/bash` 修复此问题