### PR TITLE
fix 修复了apk文件解析失败导致的应用名称没有，应用图标没有等等问题

### DIFF
--- a/fir-cli.gemspec
+++ b/fir-cli.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'thor',           '~> 0.19'
   spec.add_dependency 'rest-client',    '~> 2.0'
-  spec.add_dependency 'ruby_android',   '~> 0.7.7'
+  spec.add_dependency 'ruby_android_apk',   '~> 0.7.7.1'
   spec.add_dependency 'rqrcode',        '~> 0.7'
   spec.add_dependency 'CFPropertyList'
   spec.add_dependency 'api_tools', '~> 0.1.0'


### PR DESCRIPTION
fix 修复了ruby_apk中有些apk解析报错 label: undefined method attributes for nil
虽然catch到了，但是应用名称没有，应用图标没有的问题